### PR TITLE
Guard against undefined legend

### DIFF
--- a/src/angular-dygraphs.js
+++ b/src/angular-dygraphs.js
@@ -104,7 +104,7 @@ angular.module("angular-dygraphs", [
                         return;
                     console.log(event, x, points, row);
                     var html = "<table><tr><th colspan='2'>";
-                    if (typeof moment === "function") {
+                    if (typeof moment === "function" && scope.legend !== undefined) {
                         html += moment(x).format(scope.legend.dateFormat);
                     }
                     else {


### PR DESCRIPTION
If `scope.legend` is undefined, the next line throws and error.